### PR TITLE
[Mac]: Refactor uptime method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,69 @@
 # Add command to build by operative system
+SHELL=/usr/bin/env bash
+PROJECTNAME=$(shell basename "$(PWD)")
+PWD_PROJECT=$(shell pwd)
+LDFLAGS="-X 'main.buildTime=$(shell date)' -X 'main.lastCommit=$(shell git rev-parse HEAD)' -X 'main.semanticVersion=$(shell git describe --tags --dirty=-dev)'"
+GOOS_LINUX="linux"
+GOOS_MAC="darwin"
+GOOS_WINDOWS="windows"
+
+GOARCH_AMD64="amd64"
+GOARCH_ARM="arm"
+GOARCH_ARM64="arm64"
+
+## help: Get more info on make commands.
+help: Makefile
+	@echo " Choose a command run in "$(PROJECTNAME)":"
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+.PHONY: help
+
+## build-linux-amd64: Build gofetch for linux amd64
+build-linux-amd64:
+	@echo "--> Building gofetch binary for $(GOOS_LINUX):$(GOARCH_AMD64)"
+	@env GOOS=$(GOOS_LINUX) GOACH=$(GOARCH_AMD64) go build -o gofetch ./cmd/linux
+	@echo "--> gofetch for $(GOOS_LINUX):$(GOARCH_AMD64) built at $(PWD_PROJECT)"
+.PHONY: build-linux-amd64
+
+## build-linux-arm: Build gofetch for linux arm
+build-linux-arm:
+	@echo "--> Building gofetch binary for $(GOOS_LINUX):$(GOARCH_ARM)"
+	@env GOOS=$(GOOS_LINUX) GOACH=$(GOARCH_ARM) go build -o gofetch ./cmd/linux
+	@echo "--> gofetch for $(GOOS_LINUX):$(GOARCH_ARM) built at $(PWD_PROJECT)"
+.PHONY: build-linux-arm
+
+## build-linux-arm64: Build gofetch for linux arm64
+build-linux-arm64:
+	@echo "--> Building gofetch binary for $(GOOS_LINUX):$(GOARCH_ARM64)"
+	@env GOOS=$(GOOS_LINUX) GOACH=$(GOARCH_ARM64) go build -o gofetch ./cmd/linux
+	@echo "--> gofetch for $(GOOS_LINUX):$(GOARCH_ARM64) built at $(PWD_PROJECT)"
+.PHONY: build-linux-arm64
+
+## build-mac-amd64: Build gofetch for mac amd64
+build-mac-amd64:
+	@echo "--> Building gofetch binary for $(GOOS_MAC):$(GOARCH_AMD64)"
+	@env GOOS=$(GOOS_MAC) GOACH=$(GOOS_MAC) go build -o gofetch ./cmd/mac
+	@echo "--> gofetch for $(GOOS_MAC):$(GOARCH_AMD64) built at $(PWD_PROJECT)"
+.PHONY: build-mac-amd64
+
+## build-mac-arm: Build gofetch for mac arm
+build-mac-arm:
+	@echo "--> Building gofetch binary for $(GOOS_MAC):$(GOARCH_ARM)"
+	@env GOOS=$(GOOS_MAC) GOACH=$(GOOS_MAC) go build -o gofetch ./cmd/mac
+	@echo "--> gofetch for $(GOOS_MAC):$(GOARCH_ARM) built at $(PWD_PROJECT)"
+.PHONY: build-mac-arm
+
+## build-mac-arm64: Build gofetch for mac arm64
+build-mac-arm64:
+	@echo "--> Building gofetch binary for $(GOOS_MAC):$(GOARCH_ARM64)"
+	@env GOOS=$(GOOS_MAC) GOACH=$(GOOS_MAC) go build -o gofetch ./cmd/mac
+	@echo "--> gofetch for $(GOOS_MAC):$(GOARCH_ARM64) built at $(PWD_PROJECT)"
+.PHONY: build-mac-arm64
+
+## build-windows-amd64: Build gofetch for windows amd64
+build-windows-amd64:
+	@echo "--> Building gofetch binary for $(windows):$(GOARCH_AMD64)"
+	@env GOOS=$(windows) GOACH=$(windows) go build -o gofetch ./cmd/mac
+	@echo "--> gofetch for $(windows):$(GOARCH_AMD64) built at $(PWD_PROJECT)"
+.PHONY: build-windows-amd64
+
+

--- a/command/os_information.go
+++ b/command/os_information.go
@@ -12,15 +12,15 @@ import (
 )
 
 var (
-	Red     *color.Color
-	Green   *color.Color
-	Cyan    *color.Color
-	Yellow  *color.Color
-	Blue    *color.Color
-	Magenta *color.Color
-	White   *color.Color
-	Colors  []*color.Color
-	Info    map[string]string
+	Red         *color.Color
+	Green       *color.Color
+	Cyan        *color.Color
+	Yellow      *color.Color
+	Blue        *color.Color
+	Magenta     *color.Color
+	White       *color.Color
+	Colors      []*color.Color
+	ShortenInfo map[string]string
 )
 
 func init() {
@@ -33,7 +33,7 @@ func init() {
 	White = color.New(color.FgWhite, color.Bold)
 
 	Colors = []*color.Color{Red, Green, Cyan, Yellow, Blue, Magenta}
-	Info = map[string]string{
+	ShortenInfo = map[string]string{
 		"GetOSVersion":          "OS",
 		"GetName":               "name",
 		"GetHostname":           "host",
@@ -164,5 +164,5 @@ func Fetch(in Informer) {
 func RandColor(s string) string {
 	l := len(Colors)
 	index := rand.Intn(l-0) + 0
-	return Colors[index].Sprint(Info[s])
+	return Colors[index].Sprint(ShortenInfo[s])
 }

--- a/command/os_information.go
+++ b/command/os_information.go
@@ -32,19 +32,19 @@ func init() {
 	Magenta = color.New(color.FgHiMagenta, color.Bold)
 	White = color.New(color.FgWhite, color.Bold)
 
-	Colors = []*color.Color{Red, Green, Cyan, Yellow, Blue, Magenta, White}
+	Colors = []*color.Color{Red, Green, Cyan, Yellow, Blue, Magenta}
 	Info = map[string]string{
-		"GetOSVersion":          "os",
+		"GetOSVersion":          "OS",
 		"GetName":               "name",
 		"GetHostname":           "host",
 		"GetUptime":             "uptime",
 		"GetNumberPackages":     "packages",
 		"GetShellInformation":   "shell",
 		"GetResolution":         "resolution",
-		"GetDesktopEnvironment": "de",
+		"GetDesktopEnvironment": "DE",
 		"GetTerminalInfo":       "terminal",
-		"GetGPU":                "gpu",
-		"GetCPU":                "cpu",
+		"GetGPU":                "GPU",
+		"GetCPU":                "CPU",
 		"GetMemoryUsage":        "memory",
 	}
 }

--- a/common.go
+++ b/common.go
@@ -1,0 +1,19 @@
+package gofetch
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func ParseUptime(s string) (string, error) {
+	seconds, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return "", err
+	}
+
+	minutes := seconds / 60 % 60
+	hours := seconds / 60 / 60 % 24
+	days := seconds / 60 / 60 / 24
+
+	return fmt.Sprintf("%d day(s), %d hour(s), %d minutes(s)", days, hours, minutes), nil
+}

--- a/linux.go
+++ b/linux.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/OrlandoRomo/gofetch/command"
@@ -88,16 +87,7 @@ func (l *linux) GetUptime() (string, error) {
 		return "", err
 	}
 
-	s, err := strconv.ParseInt(seconds, 10, 32)
-	if err != nil {
-		return "", err
-	}
-
-	minutes := s / 60 % 60
-	hours := s / 60 / 60 % 24
-	days := s / 60 / 60 / 24
-
-	return fmt.Sprintf("%d day(s), %d hour(s), %d minutes(s)", days, hours, minutes), nil
+	return ParseUptime(seconds)
 }
 
 // GetNumberPackages return the number of packages installed by the current package manager


### PR DESCRIPTION
### Summary
- Refactor `uptime` method for mac.
- Refactor goroutines for getting the os information
- Add makefile commands to build the following supported systems:
  - `linux`/`amd64` 
  - `linux`/`arm` 
  - `linux`/`arm64` 
  - `mac`/`amd64` 
  - `mac`/`amd64` 
  - `mac`/`amd64` 
  - `linux`/`amd64`  
 