### PR TITLE
OS name and version

### DIFF
--- a/pkg/linux/os_version.go
+++ b/pkg/linux/os_version.go
@@ -1,12 +1,29 @@
 package linux
 
-import "strings"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var regexOS *regexp.Regexp
 
 // GetHostname returns the hostname of the linux distro.
 func (l *linux) GetOSVersion() string {
-	output, err := execCommand("uname", "-srm").CombinedOutput()
+	regexOS = regexp.MustCompile(`(NAME|VERSION)=(.+)`)
+	// To get os name and version let's use the follow command: grep -E -i -w 'VERSION|NAME' /etc/os-release.
+	output, err := execCommand("grep", "-E -i -w", "/etc/os-release").CombinedOutput()
 	if err != nil {
 		return "Unknown"
 	}
+
+	osVersion := strings.TrimSuffix(string(output), "\n")
+
+	if !regexOS.MatchString(osVersion) {
+		return "Unknown"
+	}
+
+	matches := regexOS.FindStringSubmatch(osVersion)
+	fmt.Println(matches)
 	return strings.TrimSuffix(string(output), "\n")
 }

--- a/pkg/linux/os_version_test.go
+++ b/pkg/linux/os_version_test.go
@@ -7,12 +7,17 @@ import (
 	"testing"
 )
 
+var isOSNameCommand = true
+
 func TestOSHelper(t *testing.T) {
-	if os.Getenv("GO_WANT_HELPER_PROCESS_OS") != "1" && os.Getenv("GO_WANT_HELPER_PROCESS_OS_FAILURE") != "1" {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_OS_NAME") != "1" && os.Getenv("GO_WANT_HELPER_PROCESS_OS_VERSION") != "1" && os.Getenv("GO_WANT_HELPER_PROCESS_OS_FAILURE") != "1" {
 		return
 	}
-	if os.Getenv("GO_WANT_HELPER_PROCESS_OS") == "1" {
-		fmt.Fprintf(os.Stdout, "Ubuntu 22.04")
+	if os.Getenv("GO_WANT_HELPER_PROCESS_OS_NAME") == "1" {
+		fmt.Fprintf(os.Stdout, `NAME="Ubuntu"`)
+	}
+	if os.Getenv("GO_WANT_HELPER_PROCESS_OS_VERSION") == "1" {
+		fmt.Fprintf(os.Stdout, `VERSION="22.04 LTS (Jellyfish)"`)
 	}
 	if os.Getenv("GO_WANT_HELPER_PROCESS_OS_FAILURE") == "1" {
 		os.Exit(1)
@@ -28,13 +33,30 @@ func TestGetOSVersion(t *testing.T) {
 		FakeExecCommand func(command string, args ...string) *exec.Cmd
 	}{
 		{
-			Desc:     "success - received os version",
-			Expected: "Ubuntu 22.04",
+			Desc:     "success - received os",
+			Expected: "Ubuntu 22.04 LTS (Jellyfish)",
 			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
 				cs := []string{"-test.run=TestOSHelper", "--", command}
 				cs = append(cs, args...)
 				cmd := exec.Command(os.Args[0], cs...)
-				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS=1"}
+				if isOSNameCommand {
+					cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_NAME=1"}
+					isOSNameCommand = false
+					return cmd
+				}
+
+				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_VERSION=1"}
+				return cmd
+			},
+		},
+		{
+			Desc:     "unable to get os name",
+			Expected: "Unknown",
+			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
+				cs := []string{"-test.run=TestOSHelper", "--", command}
+				cs = append(cs, args...)
+				cmd := exec.Command(os.Args[0], cs...)
+				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_FAILURE=1"}
 				return cmd
 			},
 		},
@@ -45,8 +67,15 @@ func TestGetOSVersion(t *testing.T) {
 				cs := []string{"-test.run=TestOSHelper", "--", command}
 				cs = append(cs, args...)
 				cmd := exec.Command(os.Args[0], cs...)
+				if isOSNameCommand {
+					cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_NAME=1"}
+					isOSNameCommand = false
+					return cmd
+				}
+
 				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_FAILURE=1"}
 				return cmd
+
 			},
 		},
 	}
@@ -62,6 +91,10 @@ func TestGetOSVersion(t *testing.T) {
 			if os != tc.Expected {
 				t.Fatalf("received %s but expected %s", os, tc.Expected)
 			}
+
+			t.Cleanup(func() {
+				isOSNameCommand = true
+			})
 		})
 	}
 }


### PR DESCRIPTION
Refactor `GetOSVersion` function by getting the name of the current operative system and its version.
### `GetOSVersion` in action
```bash
❯ ./gofetch 

○       ○       ○       ○       ○       ○       ○  

⠀⠀⠀⠀⠀⠀⠀⠀⢀⣤⣶⣾⣿⣿⣿⣿⣿⣿⣶⣦⣄⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⢠⡶⣦⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⡴⣦⠀⠀ name ~ orlandoromo@ROMO
⠀⠀⠀⠀⠀⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⠉⠀⠀ OS ~ Ubuntu 22.04 LTS (Jammy Jellyfish) <---------
⠀⠀⠀⠀⠀⠀⣿⣿⣿⣟⠁⠊⣿⣿⣿⣿⣿⡏⠒⠈⣿⣿⣿⡇⠀⠀⠀ uptime ~ 0 day(s), 0 hour(s), 1 minutes(s)
⠀⠀⠀⠀⠀⠀⢿⣿⣿⣿⣷⣾⣿⣿⠿⠿⣿⣿⣶⣾⣿⣿⣿⡇⠀⠀⠀ packages ~ 2053
⠀⠀⠀⠀⠀⠀⢸⣿⣿⣿⣿⣿⣿⣷⣤⣤⣿⣿⣿⣿⣿⣿⣿⣧⣼⠛⠀ shell ~ zsh 5.8.1
⠀⠀⠀⠀⠀⠀⣸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃⠀⠀ resolution ~ 1600x900 pixels (423x238 millimeters)
⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡏⠀⠀⠀ DE ~ Unity
⠀⠀⠀⠴⡾⠋⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀ terminal ~ xterm-256color
⠀⠀⠀⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀ CPU ~ Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz
⠀⠀⠀⠀⠀⠀⢹⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠀⠀ GPU ~ Intel Corporation CometLake-U GT2 [UHD Graphics]
⠀⠀⠀⠀⠀⠀⠀⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠏⠀⠀⠀⠀ memory ~ 1443 MB / 15744 MB
⠀⠀⠀⠀⠀⠀⠀⠀⣹⣿⠿⣿⣿⣿⣿⣿⣿⣿⣿⠿⣿⡁⠀⠀⠀⠀⠀
○       ○       ○       ○       ○       ○       ○  
```