### PR TITLE
Add GetKernelVersion

### DIFF
--- a/fetch/fetcher.go
+++ b/fetch/fetcher.go
@@ -44,6 +44,10 @@ type Usager interface {
 	GetMemoryUsage() string
 }
 
+type Kernel interface {
+	GetKernelVersion() string
+}
+
 type Fetcher interface {
 	Versioner
 	Namer
@@ -56,4 +60,5 @@ type Fetcher interface {
 	CPU
 	GPU
 	Usager
+	Kernel
 }

--- a/fetch/output.go
+++ b/fetch/output.go
@@ -23,7 +23,7 @@ var (
 
 var gopher = `
 %s
-⠀⠀⠀⠀⠀⠀⠀⠀⢀⣤⣶⣾⣿⣿⣿⣿⣿⣿⣶⣦⣄⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⢀⣤⣶⣾⣿⣿⣿⣿⣿⣿⣶⣦⣄⠀⠀⠀⠀⠀⠀ %s
 ⠀⠀⠀⠀⢠⡶⣦⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⡴⣦⠀⠀ %s
 ⠀⠀⠀⠀⠀⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⠉⠀⠀ %s
 ⠀⠀⠀⠀⠀⠀⣿⣿⣿⣟⠁⠊⣿⣿⣿⣿⣿⡏⠒⠈⣿⣿⣿⡇⠀⠀⠀ %s
@@ -44,6 +44,7 @@ func initColorFields() {
 	fields = map[string]string{
 		"GetOSVersion":          "OS",
 		"GetName":               "name",
+		"GetKernelVersion":      "kernel",
 		"GetUptime":             "uptime",
 		"GetNumberPackages":     "packages",
 		"GetShellInformation":   "shell",
@@ -92,6 +93,7 @@ func Fetch(in Fetcher) {
 		dots,
 		outputFields["name"],
 		outputFields["OS"],
+		outputFields["kernel"],
 		outputFields["uptime"],
 		outputFields["packages"],
 		outputFields["shell"],

--- a/pkg/linux/kernel.go
+++ b/pkg/linux/kernel.go
@@ -1,0 +1,5 @@
+package linux
+
+func (l *linux) GetKernelVersion() string {
+	return ""
+}

--- a/pkg/linux/kernel.go
+++ b/pkg/linux/kernel.go
@@ -1,5 +1,12 @@
 package linux
 
+import "strings"
+
 func (l *linux) GetKernelVersion() string {
-	return ""
+	output, err := execCommand("uname", "-smr").CombinedOutput()
+	if err != nil {
+		return "Unknown"
+	}
+
+	return strings.TrimSuffix(string(output), "\n")
 }

--- a/pkg/linux/kernel_test.go
+++ b/pkg/linux/kernel_test.go
@@ -1,0 +1,67 @@
+package linux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestKernelHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_KERNEL") != "1" && os.Getenv("GO_WANT_HELPER_PROCESS_KERNEL_FAILURE") != "1" {
+		return
+	}
+	if os.Getenv("GO_WANT_HELPER_PROCESS_KERNEL") == "1" {
+		fmt.Fprintf(os.Stdout, "Linux 5.15.0-40-generic x86_64")
+	}
+	if os.Getenv("GO_WANT_HELPER_PROCESS_KERNEL_FAILURE") == "1" {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+func TestGetKernelVersion(t *testing.T) {
+	tcs := []struct {
+		Desc            string
+		Expected        string
+		FakeExecCommand func(command string, args ...string) *exec.Cmd
+	}{
+		{
+			Desc:     "success - received kernel version",
+			Expected: "Linux 5.15.0-40-generic x86_64",
+			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
+				cs := []string{"-test.run=TestKernelHelper", "--", command}
+				cs = append(cs, args...)
+				cmd := exec.Command(os.Args[0], cs...)
+				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_KERNEL=1"}
+				return cmd
+			},
+		},
+		{
+			Desc:     "unable to get kernel version",
+			Expected: "Unknown",
+			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
+				cs := []string{"-test.run=TestKernelHelper", "--", command}
+				cs = append(cs, args...)
+				cmd := exec.Command(os.Args[0], cs...)
+				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_KERNEL_FAILURE=1"}
+				return cmd
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Desc, func(t *testing.T) {
+			execCommand = tc.FakeExecCommand
+			defer func() {
+				execCommand = exec.Command
+			}()
+			linux := New()
+			os := linux.GetKernelVersion()
+			if os != tc.Expected {
+				t.Fatalf("received %s but expected %s", os, tc.Expected)
+			}
+		})
+	}
+}

--- a/pkg/macos/kernel.go
+++ b/pkg/macos/kernel.go
@@ -1,0 +1,25 @@
+package macos
+
+import (
+	"regexp"
+	"strings"
+)
+
+var regexKernel *regexp.Regexp
+
+func (m *macos) GetKernelVersion() string {
+	regexKernel = regexp.MustCompile(`^[^:]*`)
+	output, err := execCommand("uname", "-v").CombinedOutput()
+	if err != nil {
+		return "Unknown"
+	}
+
+	kernel := strings.TrimSuffix(string(output), "\n")
+	if !regexKernel.MatchString(kernel) {
+		return "Unknown"
+	}
+
+	kernel = regexKernel.FindString(kernel)
+
+	return kernel
+}

--- a/pkg/macos/kernel_test.go
+++ b/pkg/macos/kernel_test.go
@@ -1,0 +1,69 @@
+package macos
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestKernelHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCCES_KERNEL") != "1" && os.Getenv("GO_WANT_HELPER_PROCCES_KERNEL_FAILURE") != "1" {
+		return
+	}
+
+	if os.Getenv("GO_WANT_HELPER_PROCCES_KERNEL") == "1" {
+		fmt.Fprintf(os.Stdout, "Kernel version 21.5.0: Tue Apr 26 21:08:22 PDT 2022; root:xnu-8020.121.3~4/RELEASE_X86_64 ")
+	}
+
+	if os.Getenv("GO_WANT_HELPER_PROCCES_KERNEL_FAILURE") == "1" {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+func TestGetKernelVersion(t *testing.T) {
+	tcs := []struct {
+		Desc            string
+		Expected        string
+		FakeExecCommand func(command string, args ...string) *exec.Cmd
+	}{
+		{
+			Desc:     "success - received kernel version",
+			Expected: "Kernel version 21.5.0",
+			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
+				cs := []string{"-test.run=TestKernelHelper", "--", command}
+				cs = append(cs, args...)
+				cmd := exec.Command(os.Args[0], cs...)
+				cmd.Env = []string{"GO_WANT_HELPER_PROCCES_KERNEL=1"}
+				return cmd
+			},
+		},
+		{
+			Desc:     "failed - unable to get kernel version",
+			Expected: "Unknown",
+			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
+				cs := []string{"-test.run=TestKernelHelper", "--", command}
+				cs = append(cs, args...)
+				cmd := exec.Command(os.Args[0], cs...)
+				cmd.Env = []string{"GO_WANT_HELPER_PROCCES_KERNEL_FAILURE=1"}
+				return cmd
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Desc, func(t *testing.T) {
+			execCommand = tc.FakeExecCommand
+			defer func() {
+				execCommand = exec.Command
+			}()
+			mac := New()
+			cpu := mac.GetKernelVersion()
+			if cpu != tc.Expected {
+				t.Fatalf("received %s but expected %s", cpu, tc.Expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `GetKernelVersion` function to get the current kernel version for linux and macos.
### Example 
```bash
❯ ./gofetch 

○       ○       ○       ○       ○       ○       ○  

⠀⠀⠀⠀⠀⠀⠀⠀⢀⣤⣶⣾⣿⣿⣿⣿⣿⣿⣶⣦⣄⠀⠀⠀⠀⠀⠀ name ~ orlandoromo@ROMO
⠀⠀⠀⠀⢠⡶⣦⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⡴⣦⠀⠀ OS ~ Ubuntu 22.04 LTS (Jammy Jellyfish)
⠀⠀⠀⠀⠀⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⠉⠀⠀ kernel ~ Linux 5.15.0-40-generic x86_64  <-----
⠀⠀⠀⠀⠀⠀⣿⣿⣿⣟⠁⠊⣿⣿⣿⣿⣿⡏⠒⠈⣿⣿⣿⡇⠀⠀⠀ uptime ~ 0 day(s), 0 hour(s), 42 minutes(s)
⠀⠀⠀⠀⠀⠀⢿⣿⣿⣿⣷⣾⣿⣿⠿⠿⣿⣿⣶⣾⣿⣿⣿⡇⠀⠀⠀ packages ~ 2092
⠀⠀⠀⠀⠀⠀⢸⣿⣿⣿⣿⣿⣿⣷⣤⣤⣿⣿⣿⣿⣿⣿⣿⣧⣼⠛⠀ shell ~ zsh 5.8.1
⠀⠀⠀⠀⠀⠀⣸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃⠀⠀ resolution ~ 1920x1080 pixels (508x286 millimeters)
⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡏⠀⠀⠀ DE ~ Unity
⠀⠀⠀⠴⡾⠋⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀ terminal ~ xterm-256color
⠀⠀⠀⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀ CPU ~ Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz
⠀⠀⠀⠀⠀⠀⢹⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠀⠀ GPU ~ Intel Corporation CometLake-U GT2 [UHD Graphics]
⠀⠀⠀⠀⠀⠀⠀⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠏⠀⠀⠀⠀ memory ~ 2192 MB / 15744 MB
⠀⠀⠀⠀⠀⠀⠀⠀⣹⣿⠿⣿⣿⣿⣿⣿⣿⣿⣿⠿⣿⡁⠀⠀⠀⠀⠀
○       ○       ○       ○       ○       ○       ○  
```