### PR TITLE
[GOFETCH-3]: Improve GetNumberPackages

### DIFF
--- a/pkg/linux/os_version.go
+++ b/pkg/linux/os_version.go
@@ -10,22 +10,15 @@ var regexOS *regexp.Regexp
 
 // GetHostname returns the hostname of the linux distro.
 func (l *linux) GetOSVersion() string {
-	regexOS = regexp.MustCompile(`[^NAME|VERSION=].+`)
+	regexOS = regexp.MustCompile(`[^PRETTY_NAME=].+`)
 	cmd := "grep -E -i -w '%s' /etc/os-release"
-	output, err := execCommand("bash", "-c", fmt.Sprintf(cmd, "NAME")).CombinedOutput()
+	output, err := execCommand("bash", "-c", fmt.Sprintf(cmd, "PRETTY_NAME")).CombinedOutput()
 	if err != nil {
 		return "Unknown"
 	}
 	name := match(output)
 
-	output, err = execCommand("bash", "-c", fmt.Sprintf(cmd, "VERSION")).CombinedOutput()
-	if err != nil {
-		return "Unknown"
-	}
-
-	version := match(output)
-
-	return name + " " + version
+	return name
 }
 
 func match(input []byte) string {

--- a/pkg/linux/os_version_test.go
+++ b/pkg/linux/os_version_test.go
@@ -7,17 +7,12 @@ import (
 	"testing"
 )
 
-var isOSNameCommand = true
-
 func TestOSHelper(t *testing.T) {
-	if os.Getenv("GO_WANT_HELPER_PROCESS_OS_NAME") != "1" && os.Getenv("GO_WANT_HELPER_PROCESS_OS_VERSION") != "1" && os.Getenv("GO_WANT_HELPER_PROCESS_OS_FAILURE") != "1" {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_OS") != "1" && os.Getenv("GO_WANT_HELPER_PROCESS_OS_FAILURE") != "1" {
 		return
 	}
-	if os.Getenv("GO_WANT_HELPER_PROCESS_OS_NAME") == "1" {
-		fmt.Fprintf(os.Stdout, `NAME="Ubuntu"`)
-	}
-	if os.Getenv("GO_WANT_HELPER_PROCESS_OS_VERSION") == "1" {
-		fmt.Fprintf(os.Stdout, `VERSION="22.04 LTS (Jellyfish)"`)
+	if os.Getenv("GO_WANT_HELPER_PROCESS_OS") == "1" {
+		fmt.Fprintf(os.Stdout, `PRETTY_NAME="Ubuntu 22.04 LTS"`)
 	}
 	if os.Getenv("GO_WANT_HELPER_PROCESS_OS_FAILURE") == "1" {
 		os.Exit(1)
@@ -34,18 +29,12 @@ func TestGetOSVersion(t *testing.T) {
 	}{
 		{
 			Desc:     "success - received os",
-			Expected: "Ubuntu 22.04 LTS (Jellyfish)",
+			Expected: "Ubuntu 22.04 LTS",
 			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
 				cs := []string{"-test.run=TestOSHelper", "--", command}
 				cs = append(cs, args...)
 				cmd := exec.Command(os.Args[0], cs...)
-				if isOSNameCommand {
-					cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_NAME=1"}
-					isOSNameCommand = false
-					return cmd
-				}
-
-				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_VERSION=1"}
+				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS=1"}
 				return cmd
 			},
 		},
@@ -58,24 +47,6 @@ func TestGetOSVersion(t *testing.T) {
 				cmd := exec.Command(os.Args[0], cs...)
 				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_FAILURE=1"}
 				return cmd
-			},
-		},
-		{
-			Desc:     "unable to get os version",
-			Expected: "Unknown",
-			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
-				cs := []string{"-test.run=TestOSHelper", "--", command}
-				cs = append(cs, args...)
-				cmd := exec.Command(os.Args[0], cs...)
-				if isOSNameCommand {
-					cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_NAME=1"}
-					isOSNameCommand = false
-					return cmd
-				}
-
-				cmd.Env = []string{"GO_WANT_HELPER_PROCESS_OS_FAILURE=1"}
-				return cmd
-
 			},
 		},
 	}
@@ -91,10 +62,6 @@ func TestGetOSVersion(t *testing.T) {
 			if os != tc.Expected {
 				t.Fatalf("received %s but expected %s", os, tc.Expected)
 			}
-
-			t.Cleanup(func() {
-				isOSNameCommand = true
-			})
 		})
 	}
 }

--- a/pkg/linux/package_test.go
+++ b/pkg/linux/package_test.go
@@ -19,7 +19,10 @@ func TestNumberPackagesHelper(t *testing.T) {
 	}
 
 	if os.Getenv("GO_WANT_HELPER_PROCESS_PKG_NUMBER") == "1" {
-		fmt.Fprintf(os.Stdout, "234")
+		fmt.Fprintf(os.Stdout, `warning: database file for 'extra' does not exist
+warning: database file for 'community' does not exist
+error: failed to prepare transaction (could not find database)
+234`)
 	}
 
 	if os.Getenv("GO_WANT_HELPER_PROCESS_PKG_FAILURE") == "1" {
@@ -37,7 +40,7 @@ func TestGetNumberPackages(t *testing.T) {
 	}{
 		{
 			Desc:     "success - received number of packages",
-			Expected: "234",
+			Expected: "234 (pacman)",
 			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
 				cs := []string{"-test.run=TestNumberPackagesHelper", "--", command}
 				cs = append(cs, args...)

--- a/pkg/macos/package.go
+++ b/pkg/macos/package.go
@@ -1,6 +1,7 @@
 package macos
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -13,5 +14,6 @@ func (m *macos) GetNumberPackages() string {
 	}
 	number := strings.TrimSuffix(string(output), "\n")
 
-	return strings.TrimSpace(number)
+	number = strings.TrimSpace(number)
+	return fmt.Sprintf("%s (%s)", number, "brew")
 }

--- a/pkg/macos/package_test.go
+++ b/pkg/macos/package_test.go
@@ -31,7 +31,7 @@ func TestGetNumberPackages(t *testing.T) {
 	}{
 		{
 			Desc:     "success - received number of packages",
-			Expected: "604",
+			Expected: "604 (brew)",
 			FakeExecCommand: func(command string, args ...string) *exec.Cmd {
 				cs := []string{"-test.run=TestPackageHelper", "--", command}
 				cs = append(cs, args...)


### PR DESCRIPTION
## Description

- Improve `GetNumberPackages` function by adding next to the number of packages the package manager name
- Improve `GetOSVersion` function by using the `PRETTY_NAME` from the `/etc/os-release` file.
- Fix bug about printing warnings messages with the number of total of packages under distros with pacman package manager.
## Example in ubuntu
```bash
❯ ./gofetch

○       ○       ○       ○       ○       ○       ○  

⠀⠀⠀⠀⠀⠀⠀⠀⢀⣤⣶⣾⣿⣿⣿⣿⣿⣿⣶⣦⣄⠀⠀⠀⠀⠀⠀ name ~ orlandoromo@ROMO
⠀⠀⠀⠀⢠⡶⣦⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⡴⣦⠀⠀ OS ~ Ubuntu 22.04 LTS
⠀⠀⠀⠀⠀⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⠉⠀⠀ kernel ~ Linux 5.15.0-40-generic x86_64
⠀⠀⠀⠀⠀⠀⣿⣿⣿⣟⠁⠊⣿⣿⣿⣿⣿⡏⠒⠈⣿⣿⣿⡇⠀⠀⠀ uptime ~ 0 day(s), 0 hour(s), 7 minutes(s)
⠀⠀⠀⠀⠀⠀⢿⣿⣿⣿⣷⣾⣿⣿⠿⠿⣿⣿⣶⣾⣿⣿⣿⡇⠀⠀⠀ packages ~ 2092 (dpkg)
⠀⠀⠀⠀⠀⠀⢸⣿⣿⣿⣿⣿⣿⣷⣤⣤⣿⣿⣿⣿⣿⣿⣿⣧⣼⠛⠀ shell ~ zsh 5.8.1
⠀⠀⠀⠀⠀⠀⣸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃⠀⠀ resolution ~ 1920x1080 pixels (508x286 millimeters)
⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡏⠀⠀⠀ DE ~ Unity
⠀⠀⠀⠴⡾⠋⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀ terminal ~ xterm-256color
⠀⠀⠀⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀ CPU ~ Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz
⠀⠀⠀⠀⠀⠀⢹⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠀⠀ GPU ~ Intel Corporation CometLake-U GT2 [UHD Graphics]
⠀⠀⠀⠀⠀⠀⠀⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠏⠀⠀⠀⠀ memory ~ 1422 MB / 15744 MB
⠀⠀⠀⠀⠀⠀⠀⠀⣹⣿⠿⣿⣿⣿⣿⣿⣿⣿⣿⠿⣿⡁⠀⠀⠀⠀⠀
○       ○       ○       ○       ○       ○       ○  
``` 

### Example in **Manjaro** under the pacman package manager.
![Screenshot from 2022-07-06 21-10-58](https://user-images.githubusercontent.com/34588445/177675259-d4fcbe35-7e53-40d3-9bce-785e88c8be6f.png)
